### PR TITLE
[Feature] Streamed competitive briefing with canonical enrichment and enhanced sentiment

### DIFF
--- a/exora/lib/constants.ts
+++ b/exora/lib/constants.ts
@@ -1,0 +1,32 @@
+// lib/constants.ts
+// Centralized constants shared across server modules
+
+export const TRUSTED_SOURCES_LIST: string[] = [
+  'techcrunch.com',
+  'wsj.com',
+  'bloomberg.com',
+  'forbes.com',
+  'businessinsider.com',
+  'reuters.com',
+  'theverge.com',
+  'nytimes.com',
+  'ft.com',
+  'wired.com',
+  'cnbc.com',
+  'cnn.com',
+  'bbc.com',
+];
+
+export const TRUSTED_SOURCES = new Set<string>(TRUSTED_SOURCES_LIST);
+
+export function isTrustedSource(hostname: string | undefined | null): boolean {
+  if (!hostname) return false;
+  const host = hostname.toLowerCase();
+  if (TRUSTED_SOURCES.has(host)) return true;
+  for (const base of TRUSTED_SOURCES_LIST) {
+    if (host.endsWith(`.${base}`)) return true;
+  }
+  return false;
+}
+
+


### PR DESCRIPTION
- Description:
  - Introduces SSE streaming `/api/briefing/stream` with progressive events: overview, profile, founders/leadership, company/competitor news, sentiment, summary.
  - Adds server-only key handling and an AI domain validator in `/api/briefing`.
  - Centralizes trusted news domains via `lib/constants.ts` and uses credibility-aware filtering and scoring.
  - Refactors `lib/exa-service.ts` to rate-limit, deduplicate, sort, and expose utility searches and news scoring.
  - UI updates in `app/page.tsx` for BYOK key injection, progressive state, and multi-view (overview/analysis/summary).
- Type of Change:
  - [x] New Feature
  - [x] Refactor
  - [ ] Bug Fix
  - [ ] Documentation Update
  - [ ] Chore
- How Has This Been Tested?
  - [ ] Unit tests
  - [ ] Integration tests
  - [x] Manual testing (stream end-to-end with multiple domains; verify progressive UI updates; confirm rate-limit resilience)
- Additional Context:
  - Introduces `NEWS_API_KEY` fallback path when Exa data is sparse.
  - Uses `TRUSTED_SOURCES`/`isTrustedSource` for filtering and credibility weighting.
  - Closes #1 
